### PR TITLE
Add OVR fan mode

### DIFF
--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -327,6 +327,7 @@ void BroanComponent::parseBroanFields(const std::vector<uint8_t>& message)
 				std::string strMode;
 				switch( pField->m_value.m_chValue )
 				{
+					case 0x02: strMode = "ovr"; break;
 					case 0x08: strMode = "int"; break;
 					case 0x09: strMode = "min"; break;
 					case 0x0a: strMode = "max"; break;

--- a/components/broan/broan.h
+++ b/components/broan/broan.h
@@ -56,6 +56,7 @@ enum BroanCFMMode
 enum BroanFanMode
 {
 	Off = 0x01,
+	Ovr = 0x02,
 	Intermittent = 0x08,
 	Min = 0x09,
 	Max = 0x0a,

--- a/components/broan/broan_control.cpp
+++ b/components/broan/broan_control.cpp
@@ -17,6 +17,8 @@ void BroanComponent::setFanMode( std::string mode )
 		value = 0x08;
 	else if( mode == "turbo" )
 		value = 0x0c;
+	else if( mode == "ovr" )
+		value = 0x02;
 	else
 		value = 0x01;
 

--- a/components/broan/select/__init__.py
+++ b/components/broan/select/__init__.py
@@ -35,6 +35,7 @@ async def to_code(config):
                 "int",
                 "manual",
                 "turbo",
+				"ovr",
             ],
         )
         await cg.register_parented(s, config[CONF_BROAN_ID])


### PR DESCRIPTION
This PR adds the "OVR" (Override) fan mode (0x02).  This is the mode that my Venmar HRV reports to the controller when one of the secondary override switches are used (in this case, the Venmar 20-40-60 control - https://broan-nutone.com/en-ca/accessory/41400).

