### PR TITLE
Support for half duplex with flow control pin

### DIFF
--- a/components/broan/__init__.py
+++ b/components/broan/__init__.py
@@ -45,7 +45,6 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    cg.add(var.set_role(config[CONF_ROLE]))
     if CONF_FLOW_CONTROL_PIN in config:
         pin = await gpio_pin_expression(config[CONF_FLOW_CONTROL_PIN])
         cg.add(var.set_flow_control_pin(pin))

--- a/components/broan/__init__.py
+++ b/components/broan/__init__.py
@@ -1,8 +1,11 @@
-# __init__.py
-import esphome.codegen as cg
-import esphome.config_validation as cv
-from esphome.components import uart
+from __future__ import annotations
+
+from typing import Literal
+
 from esphome import pins
+import esphome.codegen as cg
+from esphome.components import uart
+import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_FLOW_CONTROL_PIN
 from esphome.cpp_helpers import gpio_pin_expression
 
@@ -16,15 +19,15 @@ BroanComponent = broan_ns.class_("BroanComponent", cg.Component, uart.UARTDevice
 
 CONF_BROAN_ID = "broan_id"
 
-CONFIG_SCHEMA = cv.All(
+CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(BroanComponent),
             cv.Optional(CONF_FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
         }
     )
-    .extend(uart.UART_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA)
 )
 
 BroanBaseSchema = cv.Schema(
@@ -42,9 +45,10 @@ FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
 )
 
 async def to_code(config):
+    cg.add_global(broan_ns.using)
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    
+
     await uart.register_uart_device(var, config)
 
     if CONF_FLOW_CONTROL_PIN in config:

--- a/components/broan/__init__.py
+++ b/components/broan/__init__.py
@@ -40,9 +40,11 @@ FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
     parity="NONE",
     stop_bits=1,
 )
+
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+    
     await uart.register_uart_device(var, config)
 
     if CONF_FLOW_CONTROL_PIN in config:

--- a/components/broan/__init__.py
+++ b/components/broan/__init__.py
@@ -9,7 +9,6 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_FLOW_CONTROL_PIN
 from esphome.cpp_helpers import gpio_pin_expression
 
-
 AUTO_LOAD = []
 DEPENDENCIES = ["uart"]
 CODEOWNERS = ["@nspitko"]

--- a/components/broan/__init__.py
+++ b/components/broan/__init__.py
@@ -2,7 +2,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
+from esphome import pins
 from esphome.const import CONF_ID, CONF_FLOW_CONTROL_PIN
+from esphome.cpp_helpers import gpio_pin_expression
+
 
 AUTO_LOAD = []
 DEPENDENCIES = ["uart"]

--- a/components/broan/__init__.py
+++ b/components/broan/__init__.py
@@ -2,7 +2,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_FLOW_CONTROL_PIN
 
 AUTO_LOAD = []
 DEPENDENCIES = ["uart"]
@@ -17,6 +17,7 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(BroanComponent),
+            cv.Optional(CONF_FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -41,3 +42,7 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
+    cg.add(var.set_role(config[CONF_ROLE]))
+    if CONF_FLOW_CONTROL_PIN in config:
+        pin = await gpio_pin_expression(config[CONF_FLOW_CONTROL_PIN])
+        cg.add(var.set_flow_control_pin(pin))

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -534,10 +534,7 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 
 	// DEFL Copied from modbus
  	if (this->flow_control_pin_ != nullptr)
-	{
-    	this->flow_control_pin_->digital_write(false);
-		ESP_LOGD("broan","FC high");
-	}
+    	this->flow_control_pin_->digital_write(true);
 
 	uint8_t header = 0x01;
 	uint8_t alignment = 0x01;
@@ -555,10 +552,7 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 
 	// DEFL Copied from modbus
  	if (this->flow_control_pin_ != nullptr)
-	{
-    	this->flow_control_pin_->digital_write(true);
-		ESP_LOGD("broan","FC low");
-	}
+    	this->flow_control_pin_->digital_write(false);
 
 #endif
 }

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -42,7 +42,7 @@ void BroanComponent::dump_config()
 	ESP_LOGCONFIG("broan", "Flow Control Pin: %s", flow_control_pin_->dump_summary().c_str());
 }
 
-float Modbus::get_setup_priority()
+float BroanComponent::get_setup_priority()
 {
   // After UART bus
   return setup_priority::BUS - 1.0f;

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -42,7 +42,7 @@ void BroanComponent::dump_config()
 	ESP_LOGCONFIG("broan", "Flow Control Pin: %s", flow_control_pin_->dump_summary().c_str());
 }
 
-float Modbus::get_setup_priority() const
+float Modbus::get_setup_priority()
 {
   // After UART bus
   return setup_priority::BUS - 1.0f;

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -20,7 +20,7 @@ void BroanComponent::setup()
     	this->flow_control_pin_->setup();
   	}
 
-	ESP_LOGCONFIG("broan", "Done with setup");
+	ESP_LOGW("broan", "Done with setup");
 }
 
 
@@ -41,7 +41,7 @@ void BroanComponent::loop()
 void BroanComponent::set_flow_control_pin(GPIOPin *flow_control_pin)
 { 
 	this->flow_control_pin_ = flow_control_pin;
-	ESP_LOGCONFIG("broan", "Set flow control pin %i", flow_control_pin);
+	ESP_LOGW("broan", "Set flow control pin %i", flow_control_pin);
 }
 
 bool BroanComponent::readHeader()

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -39,7 +39,7 @@ void BroanComponent::loop()
 void BroanComponent::set_flow_control_pin(GPIOPin *flow_control_pin)
 { 
 	this->flow_control_pin_ = flow_control_pin;
-	ESP_LOGD("broan", "Set flow control pin %i", flow_control_pin);
+	ESP_LOGCONFIG("broan", "Set flow control pin %i", flow_control_pin);
 }
 
 bool BroanComponent::readHeader()

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -535,7 +535,7 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 	// DEFL Copied from modbus
  	if (this->flow_control_pin_ != nullptr)
 	{
-    	this->flow_control_pin_->digital_write(true);
+    	this->flow_control_pin_->digital_write(false);
 		ESP_LOGD("broan","FC high");
 	}
 
@@ -556,7 +556,7 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 	// DEFL Copied from modbus
  	if (this->flow_control_pin_ != nullptr)
 	{
-    	this->flow_control_pin_->digital_write(false);
+    	this->flow_control_pin_->digital_write(true);
 		ESP_LOGD("broan","FC low");
 	}
 

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -19,8 +19,6 @@ void BroanComponent::setup()
   	if (this->flow_control_pin_ != nullptr) {
     	this->flow_control_pin_->setup();
   	}
-
-	ESP_LOGW("broan", "Done with setup");
 }
 
 
@@ -36,6 +34,14 @@ void BroanComponent::loop()
 	replyIfAllowed();
 
 	runTasks();
+}
+
+void BroanComponent::dump_config()
+{
+	UARTDevice::dump_config();
+
+	ESP_LOGCONFIG("broan", "Set flow control pin %i", this->flow_control_pin_);
+
 }
 
 void BroanComponent::set_flow_control_pin(GPIOPin *flow_control_pin)

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -552,7 +552,7 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 
 	// DEFL Copied from modbus
  	if (this->flow_control_pin_ != nullptr)
-    	this->flow_control_pin_->digital_write(false);
+    	this->flow_control_pin_->digital_write(true);
 
 #endif
 }

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -529,7 +529,10 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 
 	// DEFL Copied from modbus
  	if (this->flow_control_pin_ != nullptr)
+	{
     	this->flow_control_pin_->digital_write(true);
+		ESP_LOGD("broan","FC high");
+	}
 
 	uint8_t header = 0x01;
 	uint8_t alignment = 0x01;
@@ -547,7 +550,11 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 
 	// DEFL Copied from modbus
  	if (this->flow_control_pin_ != nullptr)
+	{
     	this->flow_control_pin_->digital_write(false);
+		ESP_LOGD("broan","FC low");
+	}
+
 #endif
 }
 

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -39,7 +39,7 @@ void BroanComponent::loop()
 void BroanComponent::dump_config()
 {
 	ESP_LOGCONFIG("broan", "Broan:");
-  	LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
+	ESP_LOGCONFIG("broan", "Flow Control Pin: %s", flow_control_pin_->dump_summary().c_str());
 }
 
 float Modbus::get_setup_priority() const

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -38,7 +38,7 @@ void BroanComponent::loop()
 
 void BroanComponent::dump_config()
 {
-	LOG_PIN("broan", "Flow control pin (from uart): ", this->flow_control_pin_);
+	ESP_LOGCONFIG("broan", "Flow control pin (from uart): %i", this->flow_control_pin_);
 }
 
 bool BroanComponent::readHeader()

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -19,6 +19,8 @@ void BroanComponent::setup()
   	if (this->flow_control_pin_ != nullptr) {
     	this->flow_control_pin_->setup();
   	}
+
+	ESP_LOGCONFIG("broan", "Done with setup");
 }
 
 

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -38,10 +38,7 @@ void BroanComponent::loop()
 
 void BroanComponent::dump_config()
 {
-	UARTDevice::dump_config();
-
 	ESP_LOGCONFIG("broan", "Set flow control pin %i", this->flow_control_pin_);
-
 }
 
 void BroanComponent::set_flow_control_pin(GPIOPin *flow_control_pin)

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -39,7 +39,8 @@ void BroanComponent::loop()
 void BroanComponent::dump_config()
 {
 	ESP_LOGCONFIG("broan", "Broan:");
-	ESP_LOGCONFIG("broan", "Flow Control Pin: %s", flow_control_pin_->dump_summary().c_str());
+	if(this->flow_control_pin_!= nullptr)
+		ESP_LOGCONFIG("broan", "Flow Control Pin: %s", this->flow_control_pin_->dump_summary().c_str());
 }
 
 float BroanComponent::get_setup_priority() const
@@ -543,7 +544,7 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
  	if (this->flow_control_pin_ != nullptr)
 	{
     	this->flow_control_pin_->digital_write(true);
-		ESP_LOGD("broan","FC high");
+		// ESP_LOGD("broan","FC high");
 	}
 
 	uint8_t header = 0x01;
@@ -564,7 +565,7 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
  	if (this->flow_control_pin_ != nullptr)
 	{
     	this->flow_control_pin_->digital_write(false);
-		ESP_LOGD("broan","FC low");
+		// ESP_LOGD("broan","FC low");
 	}
 
 #endif

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -15,10 +15,8 @@ void BroanComponent::setup()
 	for( int i=0; i<BroanField::MAX_FIELDS; i++ )
 		m_vecFields[i].markDirty();
 
-	// DEFL: Copied from modbus
-  	if (this->flow_control_pin_ != nullptr) {
+  	if(flow_control_pin_)
     	this->flow_control_pin_->setup();
-  	}
 }
 
 
@@ -39,7 +37,7 @@ void BroanComponent::loop()
 void BroanComponent::dump_config()
 {
 	ESP_LOGCONFIG("broan", "Broan:");
-	if(this->flow_control_pin_!= nullptr)
+	if(flow_control_pin_)
 		ESP_LOGCONFIG("broan", "Flow Control Pin: %s", this->flow_control_pin_->dump_summary().c_str());
 }
 
@@ -91,7 +89,6 @@ bool BroanComponent::readHeader()
 void BroanComponent::writeRegisters( const std::vector<BroanField_t> &values )
 {
 	std::vector<uint8_t> message;
-
 
 	message.push_back(0x40); // Write
 
@@ -539,13 +536,8 @@ void BroanComponent::handleUnknownField(uint32_t nOpcodeHigh, uint32_t nOpcodeLo
 void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 {
 #ifndef LISTEN_ONLY
-
-	// DEFL Copied from modbus
- 	if (this->flow_control_pin_ != nullptr)
-	{
-    	this->flow_control_pin_->digital_write(true);
-		// ESP_LOGD("broan","FC high");
-	}
+ 	if(flow_control_pin_)
+    	flow_control_pin_->digital_write(true);
 
 	uint8_t header = 0x01;
 	uint8_t alignment = 0x01;
@@ -561,13 +553,8 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 
 	flush();
 
-	// DEFL Copied from modbus
- 	if (this->flow_control_pin_ != nullptr)
-	{
-    	this->flow_control_pin_->digital_write(false);
-		// ESP_LOGD("broan","FC low");
-	}
-
+ 	if(flow_control_pin_)
+    	flow_control_pin_->digital_write(false);
 #endif
 }
 

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -38,13 +38,7 @@ void BroanComponent::loop()
 
 void BroanComponent::dump_config()
 {
-	ESP_LOGCONFIG("broan", "Set flow control pin %i", this->flow_control_pin_);
-}
-
-void BroanComponent::set_flow_control_pin(GPIOPin *flow_control_pin)
-{ 
-	this->flow_control_pin_ = flow_control_pin;
-	ESP_LOGW("broan", "Set flow control pin %i", flow_control_pin);
+	LOG_PIN("broan", "Flow control pin (from uart): ", this->flow_control_pin_);
 }
 
 bool BroanComponent::readHeader()

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -36,6 +36,12 @@ void BroanComponent::loop()
 	runTasks();
 }
 
+void BroanComponent::set_flow_control_pin(GPIOPin *flow_control_pin)
+{ 
+	this->flow_control_pin_ = flow_control_pin;
+	ESP_LOGD("broan", "Set flow control pin %i", flow_control_pin);
+}
+
 bool BroanComponent::readHeader()
 {
 	if( m_bHaveHeader )

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -38,7 +38,14 @@ void BroanComponent::loop()
 
 void BroanComponent::dump_config()
 {
-	ESP_LOGCONFIG("broan", "Flow control pin (from uart): %i", this->flow_control_pin_);
+	ESP_LOGCONFIG("broan", "Broan:");
+  	LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
+}
+
+float Modbus::get_setup_priority() const
+{
+  // After UART bus
+  return setup_priority::BUS - 1.0f;
 }
 
 bool BroanComponent::readHeader()
@@ -534,7 +541,10 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 
 	// DEFL Copied from modbus
  	if (this->flow_control_pin_ != nullptr)
+	{
     	this->flow_control_pin_->digital_write(true);
+		ESP_LOGD("broan","FC high");
+	}
 
 	uint8_t header = 0x01;
 	uint8_t alignment = 0x01;
@@ -552,7 +562,10 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 
 	// DEFL Copied from modbus
  	if (this->flow_control_pin_ != nullptr)
-    	this->flow_control_pin_->digital_write(true);
+	{
+    	this->flow_control_pin_->digital_write(false);
+		ESP_LOGD("broan","FC low");
+	}
 
 #endif
 }

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -42,7 +42,7 @@ void BroanComponent::dump_config()
 	ESP_LOGCONFIG("broan", "Flow Control Pin: %s", flow_control_pin_->dump_summary().c_str());
 }
 
-float BroanComponent::get_setup_priority()
+float BroanComponent::get_setup_priority() const
 {
   // After UART bus
   return setup_priority::BUS - 1.0f;

--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -14,6 +14,11 @@ void BroanComponent::setup()
 
 	for( int i=0; i<BroanField::MAX_FIELDS; i++ )
 		m_vecFields[i].markDirty();
+
+	// DEFL: Copied from modbus
+  	if (this->flow_control_pin_ != nullptr) {
+    	this->flow_control_pin_->setup();
+  	}
 }
 
 
@@ -521,6 +526,11 @@ void BroanComponent::handleUnknownField(uint32_t nOpcodeHigh, uint32_t nOpcodeLo
 void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 {
 #ifndef LISTEN_ONLY
+
+	// DEFL Copied from modbus
+ 	if (this->flow_control_pin_ != nullptr)
+    	this->flow_control_pin_->digital_write(true);
+
 	uint8_t header = 0x01;
 	uint8_t alignment = 0x01;
 	uint8_t footer = 0x04;
@@ -532,6 +542,12 @@ void BroanComponent::send(const std::vector<uint8_t>& vecMessage)
 	for (auto b : vecMessage) write(b);
 	write(calculateChecksum(m_nClientAddress, m_nServerAddress, vecMessage));
 	write(footer);
+
+	flush();
+
+	// DEFL Copied from modbus
+ 	if (this->flow_control_pin_ != nullptr)
+    	this->flow_control_pin_->digital_write(false);
 #endif
 }
 

--- a/components/broan/broan.h
+++ b/components/broan/broan.h
@@ -260,6 +260,7 @@ public:
 	void setup() override;
 	void loop() override;
 	void dump_config() override;
+	float get_setup_priority() const override;
 
 public:
 	// Control API

--- a/components/broan/broan.h
+++ b/components/broan/broan.h
@@ -261,6 +261,7 @@ public:
 	// uart overrides
 	void setup() override;
 	void loop() override;
+	void dump_config() override;
 
 public:
 	// Control API

--- a/components/broan/broan.h
+++ b/components/broan/broan.h
@@ -273,6 +273,9 @@ public:
 	void setCurrentHumidity( float humidity );
 	void setIntermittentPeriod( uint32_t period );
 
+	// DEFL: Copied from modbus
+	void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
+
 private:
 
 	uint32_t m_nLastHadControl = 0;
@@ -336,6 +339,9 @@ protected:
 	float exhaust_rpm_{0.f};
 
 	uint32_t filter_life_{0};
+
+	// DEFL: Copied from modbus
+	GPIOPin *flow_control_pin_{nullptr};
 };
 
 }  // namespace broan

--- a/components/broan/broan.h
+++ b/components/broan/broan.h
@@ -185,11 +185,9 @@ class BroanComponent : public Component, public uart::UARTDevice
 
 public:
 	const uint8_t m_nServerAddress = 0x10;
-	const uint8_t m_nClientAddress = 0x13;
-
+	const uint8_t m_nClientAddress = 0x12;
 
 	bool m_bWaitForRemote = false;
-
 
 	BroanField_t m_vecFields[BroanField::MAX_FIELDS] = {
 		// Known fields

--- a/components/broan/broan.h
+++ b/components/broan/broan.h
@@ -185,7 +185,7 @@ class BroanComponent : public Component, public uart::UARTDevice
 
 public:
 	const uint8_t m_nServerAddress = 0x10;
-	const uint8_t m_nClientAddress = 0x12;
+	const uint8_t m_nClientAddress = 0x13;
 
 
 	bool m_bWaitForRemote = false;

--- a/components/broan/broan.h
+++ b/components/broan/broan.h
@@ -69,7 +69,6 @@ enum BroanFanMode
 	Turbo = 0x0c,
 	Humidity = 0x0d,
 	Away = 0x0F, // "OTH", no idea what this actually does?
-
 };
 
 enum BroanField
@@ -113,7 +112,6 @@ enum BroanField
 	UnknownB,
 
 	MAX_FIELDS,
-
 };
 
 struct BroanField_t
@@ -253,7 +251,6 @@ public:
 		{ 0x03, 0x20, BroanFieldType::Byte, {0} }, // Unknown. Set to 0 when entering INT mode
 		{ 0x08, 0x20, BroanFieldType::Byte, {0} }, // Unknown. Set to 0 when entering SMART mode, set to 1 in continuous modes.
 */
-
 	};
 
 	// uart overrides
@@ -263,6 +260,9 @@ public:
 	float get_setup_priority() const override;
 
 public:
+	// Setup
+	void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
+
 	// Control API
 	void setFanMode( std::string mode );
 	void setFanSpeed( float speed );
@@ -273,16 +273,12 @@ public:
 	void setCurrentHumidity( float humidity );
 	void setIntermittentPeriod( uint32_t period );
 
-	// DEFL: Copied from modbus
-	void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
-
 private:
 
 	uint32_t m_nLastHadControl = 0;
 	uint32_t m_unLastHeartbeat = 0; // Next time to send heartbeat
 
 	bool m_bERVReady = false;
-
 
 #ifdef SCAN_UNKNOWN
 	// Field scanner
@@ -340,7 +336,6 @@ protected:
 
 	uint32_t filter_life_{0};
 
-	// DEFL: Copied from modbus
 	GPIOPin *flow_control_pin_{nullptr};
 };
 

--- a/components/broan/broan.h
+++ b/components/broan/broan.h
@@ -274,7 +274,7 @@ public:
 	void setIntermittentPeriod( uint32_t period );
 
 	// DEFL: Copied from modbus
-	void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
+	void set_flow_control_pin(GPIOPin *flow_control_pin);
 
 private:
 

--- a/components/broan/broan.h
+++ b/components/broan/broan.h
@@ -275,7 +275,7 @@ public:
 	void setIntermittentPeriod( uint32_t period );
 
 	// DEFL: Copied from modbus
-	void set_flow_control_pin(GPIOPin *flow_control_pin);
+	void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
 
 private:
 


### PR DESCRIPTION
Needed to get this compatible with a ESP32 that had a half duplex RS-485 only which needed manual toggling of send/receive modes. This addresses issue #8 

Config now looks like

```
uart:
  id: rs485
  tx_pin: GPIO1
  rx_pin: GPIO3
  baud_rate: 38400
  rx_buffer_size: 2048
  flow_control_pin:
    number: GPIO33
    allow_other_uses: true

broan:
  uart_id: rs485
  flow_control_pin:
    number: GPIO33
    allow_other_uses: true
```

