### PR TITLE
Add Smart mode (0x11)

### DIFF
--- a/components/broan/broan.cpp
+++ b/components/broan/broan.cpp
@@ -361,6 +361,7 @@ void BroanComponent::parseBroanFields(const std::vector<uint8_t>& message)
 					case BroanFanMode::Turbo: strMode = "turbo"; break;
 					case BroanFanMode::Humidity: strMode = "humidity"; break;
 					case BroanFanMode::Recirculate: strMode = "recirculate"; break;
+					case BroanFanMode::Smart: strMode = "smart"; break;
 
 					default: strMode = "off"; break;
 				}

--- a/components/broan/broan_control.cpp
+++ b/components/broan/broan_control.cpp
@@ -23,6 +23,8 @@ void BroanComponent::setFanMode( std::string mode )
 		value = BroanFanMode::Ovr;
 	else if( mode == "recirculate" )
 		value = BroanFanMode::Recirculate;
+	else if( mode == "smart" )
+		value = BroanFanMode::Smart;
 	else
 		value = BroanFanMode::Off;
 

--- a/components/broan/select/__init__.py
+++ b/components/broan/select/__init__.py
@@ -37,6 +37,7 @@ async def to_code(config):
                 "turbo",
                 "humidity",
                 "recirculate",
+                "smart",
 				"ovr",
             ],
         )

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,3 +4,4 @@ This folder contains some example alternate configurations for the broan compone
 
 * filter_life_days.yaml - demonstrates how to report filter life in days rather than seconds
 * humidity_control_example.yaml - example of humidity control, using a Home Assistant sensor for current humidity
+* smart_mode_example.yaml - example of Smart mode, feeding the ERV current humidity from a Home Assistant sensor while Smart mode is active

--- a/examples/smart_mode_example.yaml
+++ b/examples/smart_mode_example.yaml
@@ -1,0 +1,66 @@
+external_components:
+  - source:
+      type: git
+      url: https://github.com/nspitko/broan_erv_uart
+      ref: main
+    components: [ broan ]
+
+uart:
+  id: rs485
+  tx_pin: GPIO17 # Change these to match your rs485 tranceiver. 17/18 is txd1/rxd1
+  rx_pin: GPIO18
+  baud_rate: 38400
+  rx_buffer_size: 2048
+#  debug:
+#    direction: BOTH
+#    dummy_receiver: false
+#    sequence:
+#      - lambda: UARTDebug::log_hex(direction, bytes, ' ');
+
+broan:
+  uart_id: rs485
+  id: mybroan
+
+select:
+  - platform: broan
+    fan_mode:
+      name: "Fan Mode"
+      id: fanmode
+      on_value:                    # when the mode changes to smart, send the
+        then:                      # current humidity right away so the ERV has
+          lambda: |-               # a value to work with
+            if (x == "smart") {
+              id(mybroan).setCurrentHumidity(id(myhumidity).state);
+            }
+
+number:
+  - platform: broan
+    fan_speed:
+      name: "Fan Speed"
+
+sensor:
+  - platform: broan
+    power:
+      name: Power Draw
+    temperature:
+      name: Temperature
+    temperature_out:
+      name: Temperature2
+    filter_life:
+      name: Remaining Filter life
+  - platform: homeassistant      # retrieve humidity from a sensor in HomeAssistant
+    id: myhumidity
+    name: "Home Assistant Humidity"
+    internal: true
+    entity_id: sensor.main_thermostat_current_humidity
+    on_value:                    # when we get an update, send to the ERV
+      then:                      # but only while Smart mode is active
+        lambda: |-
+          if (id(fanmode).state == "smart") {
+            id(mybroan).setCurrentHumidity(id(myhumidity).state);
+          }
+
+button:
+  - platform: broan
+    filter_reset:
+      name: Filter Reset

--- a/examples/smart_mode_example.yaml
+++ b/examples/smart_mode_example.yaml
@@ -56,7 +56,7 @@ sensor:
     on_value:                    # when we get an update, send to the ERV
       then:                      # but only while Smart mode is active
         lambda: |-
-          if (id(fanmode).state == "smart") {
+          if (id(fanmode).current_option() == "smart") {
             id(mybroan).setCurrentHumidity(id(myhumidity).state);
           }
 


### PR DESCRIPTION
Adds support for the ERV's **Smart** fan mode.

The `BroanFanMode::Smart` enum value (`0x11`) was already defined in `broan.h` but wasn't wired up anywhere. This PR connects it so it can be selected and displayed:

- **`broan_control.cpp`** — `setFanMode()` maps `"smart"` → `BroanFanMode::Smart`.
- **`broan.cpp`** — reverse mapping publishes `"smart"` back to the select entity when the ERV reports `0x11`.
- **`select/__init__.py`** — adds `"smart"` to the fan mode select options.

Note: the `0x11` byte value was already present in the enum but I don't have hardware confirmation of it in this change; it behaves like the other simple modes (no extra CFM/speed handling required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)