### PR TITLE
Filter life reset correction. Add write to 09:30 with new filter life.

### DIFF
--- a/components/broan/broan.h
+++ b/components/broan/broan.h
@@ -249,7 +249,7 @@ public:
 		// Maintenance
 		{ 0x01, 0x30, BroanFieldType::Byte, {0}, UPDATE_RATE_SLOW }, // Set to 0x01 to reset filter
 		{ 0x08, 0x30, BroanFieldType::Int, {0}, UPDATE_RATE_SLOW }, // Number of seconds until filter needs reset. Set along side reset byte
-		{ 0x09, 0x30, BroanFieldType::Int, {0}, UPDATE_RATE_SLOW }, // FilterLifeStage. Wall controller writes the desired FilterLife here first, before FilterReset.
+		{ 0x09, 0x30, BroanFieldType::Int, {0}, UPDATE_RATE_NEVER }, // FilterLifeStage. Wall controller writes the desired FilterLife here first, before FilterReset.
 
 		// Diagnostic
 		{ 0x1A, 0x00, BroanFieldType::Int, {0}, UPDATE_RATE_FAST }, // Warning code -1 = OK, if multiple warnings, will cycle through on each read.

--- a/components/broan/broan.h
+++ b/components/broan/broan.h
@@ -110,6 +110,7 @@ enum BroanField
 	// Maintenance
 	FilterReset, // Set to 1 to reset
 	FilterLife, // default 7884000 / 3 months
+	FilterLifeStage, // 09:30. Must be preloaded with the desired FilterLife value before FilterReset is set, otherwise the ERV ignores the reset.
 
 	// Diagnostic
 	WarningCode,
@@ -248,6 +249,7 @@ public:
 		// Maintenance
 		{ 0x01, 0x30, BroanFieldType::Byte, {0}, UPDATE_RATE_SLOW }, // Set to 0x01 to reset filter
 		{ 0x08, 0x30, BroanFieldType::Int, {0}, UPDATE_RATE_SLOW }, // Number of seconds until filter needs reset. Set along side reset byte
+		{ 0x09, 0x30, BroanFieldType::Int, {0}, UPDATE_RATE_SLOW }, // FilterLifeStage. Wall controller writes the desired FilterLife here first, before FilterReset.
 
 		// Diagnostic
 		{ 0x1A, 0x00, BroanFieldType::Int, {0}, UPDATE_RATE_FAST }, // Warning code -1 = OK, if multiple warnings, will cycle through on each read.

--- a/components/broan/broan_control.cpp
+++ b/components/broan/broan_control.cpp
@@ -95,12 +95,23 @@ void BroanComponent::setFanSpeedCFM( BroanFanMode mode, BroanCFMMode direction, 
 	writeRegisters( vecFields );
 }
 
+// Sends new filter life to ERV in three steps (to mimic wall controller)
+// 1. Write new filter life with FilterLifeStage (09:30)
+// 2. Write FilterReset=1 + filter life in (08:30)
+// 3. Write new filter life again, alone
+// Not sure why new filter life needs to be repeated three times
+// and if all this is necessary.
 void BroanComponent::resetFilter()
 {
-	std::vector<BroanField_t> vecFields;
-
 	uint32_t unNewFilterLife = FILTER_LIFE_MAX;
-	uint8_t unFilterReset = 0;
+
+	std::vector<BroanField_t> vecStage;
+	vecStage.push_back( m_vecFields[FilterLifeStage].copyForUpdate( unNewFilterLife ) );
+	m_vecFields[FilterLifeStage].markDirty();
+	writeRegisters( vecStage );
+
+	std::vector<BroanField_t> vecFields;
+	uint8_t unFilterReset = 1;
 
 	vecFields.push_back( m_vecFields[FilterLife].copyForUpdate( unNewFilterLife ) );
 	vecFields.push_back( m_vecFields[FilterReset].copyForUpdate( unFilterReset ) );
@@ -109,6 +120,11 @@ void BroanComponent::resetFilter()
 	m_vecFields[FilterLife].markDirty();
 
 	writeRegisters( vecFields );
+
+	std::vector<BroanField_t> vecConfirm;
+	vecConfirm.push_back( m_vecFields[FilterLife].copyForUpdate( unNewFilterLife ) );
+	m_vecFields[FilterLife].markDirty();
+	writeRegisters( vecConfirm );
 }
 
 void BroanComponent::setHumidityControl( bool enable ) {

--- a/components/broan/broan_control.cpp
+++ b/components/broan/broan_control.cpp
@@ -107,7 +107,6 @@ void BroanComponent::resetFilter()
 
 	std::vector<BroanField_t> vecStage;
 	vecStage.push_back( m_vecFields[FilterLifeStage].copyForUpdate( unNewFilterLife ) );
-	m_vecFields[FilterLifeStage].markDirty();
 	writeRegisters( vecStage );
 
 	std::vector<BroanField_t> vecFields;


### PR DESCRIPTION
Found out that the  filter reset was not working well. With the wall controller, the filter reset in performed on three steps:
1. Write new filter life with FilterLifeStage (09:30)
2. Write FilterReset=1 + filter life in (08:30)
3. Write new filter life again, alone

It now works well.