### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainer-community/devcontainer-features/astral.sh-uv:1": {
+      "version": "1.0.6",
+      "resolved": "ghcr.io/devcontainer-community/devcontainer-features/astral.sh-uv@sha256:36f95b90080248a05aba7b1b3cecf8018bb6d7222f6274f03f050b502abd4fe7",
+      "integrity": "sha256:36f95b90080248a05aba7b1b3cecf8018bb6d7222f6274f03f050b502abd4fe7"
+    },
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "version": "1.0.6",
+      "resolved": "ghcr.io/devcontainers-extra/features/apt-packages@sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd",
+      "integrity": "sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd"
+    },
+    "ghcr.io/devcontainers-extra/features/prek:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/devcontainers-extra/features/prek@sha256:eb55e266252d8560cf726f27c5675e397bb833067a21428c50b273a59842f649",
+      "integrity": "sha256:eb55e266252d8560cf726f27c5675e397bb833067a21428c50b273a59842f649"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
+{
+	"name": "broan-erv-uart",
+
+	"image": "mcr.microsoft.com/devcontainers/cpp:3-debian13",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainer-community/devcontainer-features/astral.sh-uv:1": {},
+		"ghcr.io/devcontainers-extra/features/prek:1": {},
+		"ghcr.io/devcontainers-extra/features/apt-packages:1": {
+			"packages": "python3-venv"
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bash .devcontainer/post-create.sh",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools",
+				"ms-python.python",
+				"tamasfe.even-better-toml",
+				"charliermarsh.ruff",
+				"ms-python.pylint",
+				"ms-python.flake8"
+			]
+		}
+	},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+
+	// Allow the container to access services running on the host machine.
+	"runArgs": ["--add-host=host.docker.internal:host-gateway"]
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+uv venv --clear
+uv sync
+
+prek install --prepare-hooks

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "C_Cpp.default.compileCommands": [
+        "${workspaceFolder}/.esphome/build/broan-erv/compile_commands.json"
+    ],
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}/.esphome/build/broan-erv/src/**"
+    ],
+    "C_Cpp.default.cppStandard": "c++20"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build ESPHome",
+            "type": "shell",
+            "group" : "build",
+            "command": ".venv/bin/esphome compile examples/full_config_example.yaml"
+        }
+    ]
+}

--- a/examples/full_config_example.yaml
+++ b/examples/full_config_example.yaml
@@ -1,0 +1,40 @@
+esphome:
+  name: broan-erv
+
+esp32:
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+external_components:
+  - source:
+      type: local
+      path: components
+    components: [broan]
+
+uart:
+  id: rs485
+  tx_pin: GPIO17
+  rx_pin: GPIO18
+  baud_rate: 38400
+  rx_buffer_size: 2048
+
+broan:
+  uart_id: rs485
+
+select:
+  - platform: broan
+    fan_mode:
+      name: "fan mode"
+
+number:
+  - platform: broan
+    fan_speed:
+      name: "fan speed"
+
+sensor:
+  - platform: broan
+    power:
+      name: Power draw
+    temperature:
+      name: Temperature


### PR DESCRIPTION
This PR works as intended after merging #19, which includes the pyproject.toml and pre-commit config referenced by `.devcontainer/post-create.sh`

These changes provide a completely optional devcontainer config. The intent is that a new contributor can clone the repo, open in a devcontainer, and be immediately fully set up and able to build, format, lint, etc.

Reference:
https://code.visualstudio.com/docs/devcontainers/containers